### PR TITLE
Fix Illegal input: Field 'IPRange' is required

### DIFF
--- a/src/commonMain/kotlin/me/devnatan/dockerkt/models/network/IPAM.kt
+++ b/src/commonMain/kotlin/me/devnatan/dockerkt/models/network/IPAM.kt
@@ -26,6 +26,6 @@ public data class IPAM(
 @Serializable
 public data class IPAMConfig(
     @SerialName("Subnet") public val subnet: String,
-    @SerialName("IPRange") public val ipRange: String?,
+    @SerialName("IPRange") public val ipRange: String? = null,
     @SerialName("Gateway") public val gateway: String,
 )


### PR DESCRIPTION
Fixes
```
io.ktor.serialization.JsonConvertException: Illegal input: Field 'IPRange' is required for type with serial name 'me.devnatan.dockerkt.models.network.IPAMConfig', but it was missing at path: $.IPAM.Config[0]
```