### PR TITLE
Fix invalid flow coroutine context

### DIFF
--- a/src/commonMain/kotlin/me/devnatan/dockerkt/resource/image/ImageResource.kt
+++ b/src/commonMain/kotlin/me/devnatan/dockerkt/resource/image/ImageResource.kt
@@ -15,7 +15,7 @@ import io.ktor.http.contentType
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.json.Json
 import me.devnatan.dockerkt.io.requestCatching
 import me.devnatan.dockerkt.models.image.Image
@@ -36,7 +36,7 @@ public class ImageResource internal constructor(
     public suspend fun list(): List<ImageSummary> = httpClient.get("$BasePath/json").body()
 
     public fun pull(image: String): Flow<ImagePull> =
-        flow {
+        channelFlow {
             httpClient
                 .preparePost("$BasePath/create") {
                     parameter("fromImage", image)
@@ -44,7 +44,7 @@ public class ImageResource internal constructor(
                     val channel = response.body<ByteReadChannel>()
                     while (true) {
                         val line = channel.readUTF8Line() ?: break
-                        emit(json.decodeFromString(line))
+                        send(json.decodeFromString(line))
                     }
                 }
         }

--- a/src/commonMain/kotlin/me/devnatan/dockerkt/resource/system/SystemResource.kt
+++ b/src/commonMain/kotlin/me/devnatan/dockerkt/resource/system/SystemResource.kt
@@ -9,7 +9,7 @@ import io.ktor.client.request.prepareGet
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.json.Json
 import me.devnatan.dockerkt.io.requestCatching
 import me.devnatan.dockerkt.models.system.Event
@@ -83,7 +83,7 @@ public class SystemResource internal constructor(
      * @param options Options to filter the received events.
      */
     public fun events(options: MonitorEventsOptions = MonitorEventsOptions()): Flow<Event> =
-        flow {
+        channelFlow {
             requestCatching {
                 httpClient
                     .prepareGet("/events") {
@@ -95,7 +95,7 @@ public class SystemResource internal constructor(
                         while (true) {
                             val raw = channel.readUTF8Line() ?: break
                             val decoded = json.decodeFromString<Event>(raw)
-                            emit(decoded)
+                            send(decoded)
                         }
                     }
             }

--- a/src/jvmMain/kotlin/me/devnatan/dockerkt/resource/container/ContainerResource.jvm.kt
+++ b/src/jvmMain/kotlin/me/devnatan/dockerkt/resource/container/ContainerResource.jvm.kt
@@ -491,7 +491,7 @@ public actual class ContainerResource(
 
     @JvmSynthetic
     public actual fun attach(container: String): Flow<Frame> =
-        flow {
+        channelFlow {
             httpClient
                 .preparePost("$BasePath/$container/attach") {
                     parameter("stream", "true")
@@ -504,7 +504,7 @@ public actual class ContainerResource(
                         val line = channel.readUTF8Line() ?: break
 
                         // TODO handle stream type
-                        emit(Frame(line, line.length, Stream.StdOut))
+                        send(Frame(line, line.length, Stream.StdOut))
                     }
                 }
         }


### PR DESCRIPTION
Currently, some `flow` builders are used alongside with Ktor Http client. However, this makes the flow emissions being done in the wrong coroutine context. `channelFlow` should be used in these cases.

Othewise, when using Ktor `3.4.0`, you will get these kind of exceptions:

```
java.lang.IllegalStateException: Flow invariant is violated:
		Flow was collected in [RunningInRunTest, kotlinx.coroutines.test.TestCoroutineScheduler@4027879f, kotlinx.coroutines.test.TestScopeKt$TestScope$$inlined$CoroutineExceptionHandler$1@1be6036f, BackgroundWork, CoroutineId(23), "coroutine#23":ScopeCoroutine{Active}@2ce0344d, Dispatchers.IO],
		but emission happened in [RunningInRunTest, kotlinx.coroutines.test.TestCoroutineScheduler@4027879f, kotlinx.coroutines.test.TestScopeKt$TestScope$$inlined$CoroutineExceptionHandler$1@1be6036f, BackgroundWork, CoroutineId(23), kotlinx.coroutines.UndispatchedMarker@1f2e5d3a, "coroutine#23":UndispatchedCoroutine{Active}@63c93a3f, Dispatchers.IO].
		Please refer to 'flow' documentation or use 'flowOn' instead
	at kotlinx.coroutines.flow.internal.SafeCollector_commonKt.checkContext(SafeCollector.common.kt:84)
	at kotlinx.coroutines.flow.internal.SafeCollector.checkContext(SafeCollector.kt:132)
	at kotlinx.coroutines.flow.internal.SafeCollector.emit(SafeCollector.kt:109)
	at kotlinx.coroutines.flow.internal.SafeCollector.emit(SafeCollector.kt:82)
	at me.devnatan.dockerkt.resource.image.ImageResource$pull$1$2.invokeSuspend(ImageResource.kt:46)
	at me.devnatan.dockerkt.resource.image.ImageResource$pull$1$2.invoke(ImageResource.kt)
	at me.devnatan.dockerkt.resource.image.ImageResource$pull$1$2.invoke(ImageResource.kt)
	at io.ktor.client.statement.HttpStatement$execute$2$1.invokeSuspend(HttpStatement.kt:63)
	at io.ktor.client.statement.HttpStatement$execute$2$1.invoke(HttpStatement.kt)
	at io.ktor.client.statement.HttpStatement$execute$2$1.invoke(HttpStatement.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndspatched(Undispatched.kt:66)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:43)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at io.ktor.client.statement.HttpStatement.execute(HttpStatement.kt:62)
	at io.ktor.client.statement.HttpStatement$execute$1.invokeSuspend(HttpStatement.kt)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at io.ktor.client.statement.HttpStatement.execute(HttpStatement.kt:62)
	at me.devnatan.dockerkt.resource.image.ImageResource$pull$1.invokeSuspend(ImageResource.kt:42)
	...
```